### PR TITLE
Update the base image to use the latest upstream images

### DIFF
--- a/base-images/Dockerfile.ubuntu-lts
+++ b/base-images/Dockerfile.ubuntu-lts
@@ -1,4 +1,4 @@
-FROM --platform=amd64 ubuntu:jammy
+FROM --platform=amd64 ubuntu:latest
 
 # update packages
 RUN apt-get update && apt-get upgrade -y


### PR DESCRIPTION
Update the base image in `base-images/Dockerfile.ubuntu-lts` to use the latest upstream image.

* Change the base image from `ubuntu:jammy` to `ubuntu:latest`.
* Ensure all existing instructions remain unchanged.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/raptium/dev-setup?shareId=0eb0d683-8dd0-4c19-a176-97eca4a9e970).